### PR TITLE
feat: introduced typesafe routing using 'to()'.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,13 @@
 import React from "react"
 import { ThemeProvider, GlobalStyle } from "@datapunt/asc-ui"
-import { Router } from "@reach/router"
 
-import HomePage from "app/features/poc/pages/home/HomePage"
+import Router from "./app/features/shared/routing/Router"
 
 const App: React.FC = () => (
   <ThemeProvider>
       <GlobalStyle />
-      <Router>
-        <HomePage path="/" />
-      </Router>
+      <Router />
   </ThemeProvider>
 )
-
 
 export default App

--- a/src/app/config/routes.tsx
+++ b/src/app/config/routes.tsx
@@ -1,0 +1,9 @@
+import POCRoutes from "../features/poc/routes"
+
+const routes = {
+  // NOTE: add your own feature here for routing.
+  ...POCRoutes
+}
+
+export type Routes = typeof routes
+export default routes

--- a/src/app/features/poc/pages/foo/FooPage.tsx
+++ b/src/app/features/poc/pages/foo/FooPage.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Heading } from "@datapunt/asc-ui"
+
+import DefaultLayout from "app/features/shared/components/layouts/DefaultLayout/DefaultLayout"
+import { RouteComponentProps } from "@reach/router"
+
+type Props = {
+  bar: string
+}
+
+// NOTE: just a demo page to demonstrate route-params.
+// Please remove whenever there is a real feature introduced.
+const FooPage: React.FC<RouteComponentProps<Props>> = ({ bar }) => (
+  <DefaultLayout>
+    <Heading>Foo page</Heading>
+    <p>Route param: { bar }</p>
+  </DefaultLayout>
+)
+
+export default FooPage

--- a/src/app/features/poc/routes.tsx
+++ b/src/app/features/poc/routes.tsx
@@ -1,0 +1,8 @@
+import HomePage from "./pages/home/HomePage"
+import FooPage from "./pages/foo/FooPage"
+
+// NOTE: please add your own POC-specific routes here.
+export default {
+  "/": HomePage,
+  "/poc/foo/:bar/": FooPage
+}

--- a/src/app/features/shared/components/organisms/navigation/DefaultNavigation.tsx
+++ b/src/app/features/shared/components/organisms/navigation/DefaultNavigation.tsx
@@ -1,32 +1,34 @@
 import React from "react"
 import { MenuInline, MenuItem, MenuButton, MenuFlyOut } from "@datapunt/asc-ui"
 
+import to from "app/features/shared/routing/to"
+
 const DefaultNavigation: React.FC = () => (
   <MenuInline>
     <MenuItem>
-      <MenuButton forwardedAs="a" href="/" active>
+      <MenuButton forwardedAs="a" href={ to("/") } active>
         Home
       </MenuButton>
     </MenuItem>
     <MenuFlyOut label="Submenu">
       <MenuItem>
-        <MenuButton forwardedAs="a" href="/">
-          Egestas
+        <MenuButton forwardedAs="a" href={ to("/poc/foo/:bar/", { bar: "bar" }) }>
+          Bar Egestas
         </MenuButton>
       </MenuItem>
       <MenuItem>
-        <MenuButton forwardedAs="a" href="/">
-          Ullamcorper Fringilla
+        <MenuButton forwardedAs="a" href={ to("/poc/foo/:bar/", { bar: "foo" }) }>
+          Foo Ullamcorper Fringilla
         </MenuButton>
       </MenuItem>
     </MenuFlyOut>
     <MenuItem>
-      <MenuButton forwardedAs="a" href="/">
+      <MenuButton forwardedAs="a" href={ to("/") }>
         Lorem
       </MenuButton>
     </MenuItem>
     <MenuItem>
-      <MenuButton forwardedAs="a" href="/">
+      <MenuButton forwardedAs="a" href={ to("/") }>
         Condimentum Euismod
       </MenuButton>
     </MenuItem>

--- a/src/app/features/shared/routing/Router.tsx
+++ b/src/app/features/shared/routing/Router.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { Router as ReachRouter } from "@reach/router"
+
+import routes from "app/config/routes"
+
+const Router: React.FC = () => (
+  <ReachRouter>
+    {
+      Object
+        .entries(routes)
+        .map(([path, Page]) => <Page path={path} />)
+    }
+  </ReachRouter>
+)
+
+export default Router

--- a/src/app/features/shared/routing/to.test.ts
+++ b/src/app/features/shared/routing/to.test.ts
@@ -1,0 +1,7 @@
+import to from "./to"
+
+describe("to", () => {
+  it("should should apply route params when given", () => {
+    expect(to("/poc/foo/:bar/", { bar: "barValue" })).toEqual("/poc/foo/barValue/")
+  })
+})

--- a/src/app/features/shared/routing/to.ts
+++ b/src/app/features/shared/routing/to.ts
@@ -1,0 +1,45 @@
+import { ComponentProps, ComponentType } from "react"
+import { Routes } from "app/config/routes"
+import { RouteComponentProps } from "@reach/router"
+
+// RouteParams for given K in Routes
+type RouteParams<T extends Routes, K extends keyof T> =
+  // ... value for K should be a Component:
+  T[K] extends ComponentType
+    // Omit default RouteComponentProps, we're not interested in those. (E.g location, navigate, etc)
+    ? Omit<ComponentProps<T[K]>, keyof RouteComponentProps | "children">
+    // Don't allow anything else than Components. As we cannot safely extract component-props on anything other than a Component
+    : never
+
+// Safely convert any object to a string, even null or undefined
+const toString = (obj: any): string =>
+  typeof obj.toString === "function"
+    ? obj.toString()
+    : ""
+
+/**
+ * Example:
+ * applyRouteParams('/foo/:id/', { id: 100 });       =>      "/foo/100/"
+ */
+const applyRouteParams = <T extends Routes, K extends keyof T>
+  (url: string, params: RouteParams<T, K>): string =>
+    Object
+      .entries(params)
+      .reduce(
+        (url, [key, value]) => url.replace(`:${ key }`, toString(value)),
+        url
+      )
+
+/**
+ * Typesafe routes.
+ * Usage: `to("/foo/:id/", { id: 100 })`
+ *
+ * NOTE: Type-errors will occur when "/foo/:id" does not exit, or when the related Page-component does not accept an `id` property
+ */
+const to = <T extends Routes, K extends keyof T>
+  (path: K, params?: RouteParams<T, K>) =>
+    params !== undefined
+      ? applyRouteParams(path.toString(), params)
+      : path
+
+export default to

--- a/src/app/test/empty.test.ts
+++ b/src/app/test/empty.test.ts
@@ -1,2 +1,0 @@
-// TODO: feel free to delete eventually
-it("empty", () => expect(true).toBeTruthy())


### PR DESCRIPTION
Typesafe routing using a `to()`-function.

![route autocomplete](https://user-images.githubusercontent.com/248906/85261649-c30b8080-b46c-11ea-9248-3feaef186698.gif)
