### PR TITLE
feat: force to function to accept numbers and strings

### DIFF
--- a/src/app/features/poc/pages/foo/FooPage.tsx
+++ b/src/app/features/poc/pages/foo/FooPage.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { Heading } from "@datapunt/asc-ui"
 
 import DefaultLayout from "app/features/shared/components/layouts/DefaultLayout/DefaultLayout"
-import { RouteComponentProps } from "@reach/router"
 
 type Props = {
   bar: string
@@ -10,7 +9,7 @@ type Props = {
 
 // NOTE: just a demo page to demonstrate route-params.
 // Please remove whenever there is a real feature introduced.
-const FooPage: React.FC<RouteComponentProps<Props>> = ({ bar }) => (
+const FooPage: React.FC<Props> = ({ bar }) => (
   <DefaultLayout>
     <Heading>Foo page</Heading>
     <p>Route param: { bar }</p>

--- a/src/app/features/poc/pages/home/HomePage.tsx
+++ b/src/app/features/poc/pages/home/HomePage.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import { FormTitle, Heading } from "@datapunt/asc-ui"
-import { RouteComponentProps } from "@reach/router"
 
 import DefaultLayout from "app/features/shared/components/layouts/DefaultLayout/DefaultLayout"
-import POCForm from "../../organisms/form/POCForm"
 
-const HomePage: React.FC<RouteComponentProps> = () => (
+import POCForm from "app/features/poc/organisms/form/POCForm"
+
+const HomePage: React.FC = () => (
   <DefaultLayout>
     <Heading>Proof of Concept</Heading>
     <FormTitle>Eerste versie van een formulier in het zaaksysteem</FormTitle>

--- a/src/app/features/shared/components/organisms/navigation/DefaultNavigation.tsx
+++ b/src/app/features/shared/components/organisms/navigation/DefaultNavigation.tsx
@@ -12,7 +12,7 @@ const DefaultNavigation: React.FC = () => (
     </MenuItem>
     <MenuFlyOut label="Submenu">
       <MenuItem>
-        <MenuButton forwardedAs="a" href={ to("/poc/foo/:bar/", { bar: "bar" }) }>
+        <MenuButton forwardedAs="a" href={ to("/poc/foo/:bar/", { bar: "foo" }) }>
           Bar Egestas
         </MenuButton>
       </MenuItem>

--- a/src/app/features/shared/routing/to.ts
+++ b/src/app/features/shared/routing/to.ts
@@ -1,21 +1,16 @@
 import { ComponentProps, ComponentType } from "react"
 import { Routes } from "app/config/routes"
-import { RouteComponentProps } from "@reach/router"
 
 // RouteParams for given K in Routes
 type RouteParams<T extends Routes, K extends keyof T> =
   // ... value for K should be a Component:
-  T[K] extends ComponentType
-    // Omit default RouteComponentProps, we're not interested in those. (E.g location, navigate, etc)
-    ? Omit<ComponentProps<T[K]>, keyof RouteComponentProps | "children">
+  T[K] extends ComponentType<any>
+    // We're only interested in parameters that are either a string or a  number
+    ? Omit<ComponentProps<T[K]>, "children"> extends { [key: string]: string|number }
+        ? Omit<ComponentProps<T[K]>, "children">
+        : never
     // Don't allow anything else than Components. As we cannot safely extract component-props on anything other than a Component
     : never
-
-// Safely convert any object to a string, even null or undefined
-const toString = (obj: any): string =>
-  typeof obj.toString === "function"
-    ? obj.toString()
-    : ""
 
 /**
  * Example:
@@ -26,7 +21,7 @@ const applyRouteParams = <T extends Routes, K extends keyof T>
     Object
       .entries(params)
       .reduce(
-        (url, [key, value]) => url.replace(`:${ key }`, toString(value)),
+        (url, [key, value]) => url.replace(`:${ key }`, value.toString()),
         url
       )
 


### PR DESCRIPTION
The `to()` function only accepts numbers and strings as arguments.

NOTE: the Page component themselves could still implement other types of props, those props are just not settable through the `to()` method (or through a URL in general).