### PR TITLE
feat: introduced useNodeDimensions and implemented it in FixedTableCell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17686,8 +17686,7 @@
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-final-form": "^6.5.0",
     "react-final-form-arrays": "^3.1.1",
     "react-scripts": "3.4.1",
+    "resize-observer-polyfill": "^1.5.1",
     "styled-components": "^5.1.1",
     "typescript": "^3.9.5"
   },

--- a/src/app/features/shared/components/molecules/Table/Table.stories.tsx
+++ b/src/app/features/shared/components/molecules/Table/Table.stories.tsx
@@ -21,10 +21,11 @@ const columns = [
 ]
 
 const OpenButton: React.FC = () => <Button variant="textButton" iconSize={14} iconLeft={<ChevronRight />}>Open</Button>
+const LargerComponent: React.FC = () => <div style={{ height: "100px", border: "1px solid #ddd", padding: "8px" }}>Larger element</div>
 
 const data = [
   ["1", "Dotti", "Stinchcombe", "dstinchcombe0@phpbb.com", "Female", "11.202.107.115", <OpenButton />],
-  ["2", "Walden", "Vahey", "wvahey1@godaddy.com", "Male", "100.44.64.241", <OpenButton />],
+  ["2", "Walden", "Vahey", <LargerComponent />, "Male", "100.44.64.241", <OpenButton />],
   ["3", "Guss", "Trayhorn", "gtrayhorn2@wisc.edu", "Male", "79.159.29.210", <OpenButton />],
   ["4", "Brynne", "Bartosiak", "bbartosiak3@walmart.com", "Female", "16.8.52.4", <OpenButton />],
   ["5", "Cherey", "Garbutt", "cgarbutt4@bluehost.com", "Female", "97.173.26.92", <OpenButton />],

--- a/src/app/features/shared/components/molecules/Table/Table.test.tsx
+++ b/src/app/features/shared/components/molecules/Table/Table.test.tsx
@@ -4,6 +4,7 @@ import { mount } from "enzyme"
 import TableCell from "./components/TableCell/TableCell"
 import Table from "./Table"
 import SmallSkeleton from "../../atoms/Skeleton/SmallSkeleton"
+import FixedTableCell from "./components/TableCell/FixedTableCell"
 
 describe("Table", () => {
   const columns = ["column1", "column2"]
@@ -21,18 +22,15 @@ describe("Table", () => {
     describe("when given fixedColumnWidth", () => {
       it("should pass fixedColumnWidth to the last column", () => {
         const component = mount(<Table data={data} columns={columns} fixedColumnWidth="100px" />)
-        const cells = component.find("[fixedWidth]")
+        const fixedCells = component.find(FixedTableCell)
 
-        expect(cells.length).toEqual(3)
+        expect(fixedCells.length).toEqual(2)
 
-        expect(cells.at(0).prop("fixedWidth")).toEqual("100px")
-        expect(cells.at(0).text()).toEqual("column2")
+        expect(fixedCells.at(0).prop("fixedWidth")).toEqual("100px")
+        expect(fixedCells.at(0).text()).toEqual("bar")
 
-        expect(cells.at(1).prop("fixedWidth")).toEqual("100px")
-        expect(cells.at(1).text()).toEqual("bar")
-
-        expect(cells.at(2).prop("fixedWidth")).toEqual("100px")
-        expect(cells.at(2).text()).toEqual("baz")
+        expect(fixedCells.at(1).prop("fixedWidth")).toEqual("100px")
+        expect(fixedCells.at(1).text()).toEqual("baz")
       })
     })
   })

--- a/src/app/features/shared/components/molecules/Table/Table.tsx
+++ b/src/app/features/shared/components/molecules/Table/Table.tsx
@@ -7,6 +7,7 @@ import SmallSkeleton from "app/features/shared/components/atoms/Skeleton/SmallSk
 
 import TableCell from "./components/TableCell/TableCell"
 import TableHeading from "./components/TableHeading/TableHeading"
+import FixedTableCell from "./components/TableCell/FixedTableCell"
 
 type CellContent = string | number | JSX.Element | undefined
 
@@ -22,7 +23,7 @@ const Wrap = styled.div`
 `
 
 const HorizontalScrollContainer = styled.div<Pick<Props, "fixedColumnWidth">>`  
-  overflow-x: scroll; 
+  overflow-x: auto; 
   margin-right: ${ (props) => props.fixedColumnWidth ?? "auto" }; 
 `
 
@@ -72,10 +73,12 @@ const Table: React.FC<Props> = ({ columns, loading, fixedColumnWidth, ...restPro
           <tbody>
           { data?.map( (row, index) =>
             <Row key={index}>
-              { row.map( (cell, index) =>
-                <TableCell key={index} fixedWidth={fixedWidth(!loading && row.length - 1 === index, fixedColumnWidth)}>
-                  { loading ? <SmallSkeleton /> : cell ?? <>&nbsp;</> }
-                </TableCell>
+              { row.map( (cell, index) => {
+                  const fixed = fixedWidth(!loading && row.length - 1 === index, fixedColumnWidth)
+                  return fixed === undefined
+                    ? <TableCell key={index}>{ loading ? <SmallSkeleton /> : cell ?? <>&nbsp;</> }</TableCell>
+                    : <FixedTableCell key={index} fixedWidth={fixed}>{ cell ?? <>&nbsp;</> }</FixedTableCell>
+                }
               ) }
             </Row>
           ) }

--- a/src/app/features/shared/components/molecules/Table/components/TableCell/FixedTableCell.tsx
+++ b/src/app/features/shared/components/molecules/Table/components/TableCell/FixedTableCell.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import styled from "styled-components"
+import { themeColor, themeSpacing } from "@datapunt/asc-ui"
+
+import useNodeDimensions from "app/features/shared/hooks/useNodeDimensions/useNodeDimensions"
+import useNodeByReference from "app/features/shared/hooks/useNodeByReference/useNodeByReference"
+
+type StyledTDProps = {
+  fixedWidth?: string
+  height?: number
+}
+
+const StyledTd = styled.td<StyledTDProps>`
+  padding: ${ themeSpacing(4) } ${ themeSpacing(3) };
+  vertical-align: top;
+      
+  position: absolute;
+  right: 0;
+  
+  border-left: 1px solid ${ themeColor("tint", "level3") };
+  
+  width: ${ props => props.fixedWidth ?? "auto" };
+  height: ${ props => `${ props.height }px;` ?? "auto" };     
+`
+
+type Props = {
+  fixedWidth?: string
+}
+
+/**
+ * This table-cell is positioned absolutely, to mimic a 'fixed-column' on smaller screens.
+ *
+ * Its positioned absolutely and therefore doesn't automatically follow the 'document-flow' anymore.
+ * We calculate its height based on the height of the parent-node.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
+ */
+const FixedTableCell: React.FC<Props> = ({ children, fixedWidth }) => {
+  // Grab parent node, a table-row element (TR).
+  const { ref, node } = useNodeByReference<HTMLTableCellElement>(node => node?.parentElement ?? undefined)
+  // Grab dimensions of the table-row.
+  const dimensions = useNodeDimensions(node)
+  // Pass height of the table-row.
+  return <StyledTd ref={ref} height={dimensions?.height} fixedWidth={fixedWidth}>
+    { children }
+  </StyledTd>
+}
+
+
+export default FixedTableCell

--- a/src/app/features/shared/components/molecules/Table/components/TableCell/TableCell.tsx
+++ b/src/app/features/shared/components/molecules/Table/components/TableCell/TableCell.tsx
@@ -1,24 +1,9 @@
-import styled, { css } from "styled-components"
-import { themeColor, themeSpacing } from "@datapunt/asc-ui"
+import styled from "styled-components"
+import { themeSpacing } from "@datapunt/asc-ui"
 
-type Props = {
-  fixedWidth?: string
-}
-
-const TableCell = styled.td<Props>`  
-  padding: ${ themeSpacing(4) } ${ themeSpacing(3) };
-  min-width:200px;
-  height: 50px;
-       
-  ${ ( { fixedWidth }: Props ) => fixedWidth && css`  
-      position: absolute;
-      right: 0;
-      
-      border-left: 1px solid ${ themeColor("tint", "level3") };
-      
-      min-width: ${ fixedWidth };
-      width: ${ fixedWidth };
-  ` }   
+const TableCell = styled.td`  
+  padding: ${ themeSpacing(4) } ${ themeSpacing(3) };   
+  vertical-align: top;
 `
 
 export default TableCell

--- a/src/app/features/shared/hooks/useNodeByReference/useNodeByReference.ts
+++ b/src/app/features/shared/hooks/useNodeByReference/useNodeByReference.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react"
+
+const defaultNodeModifier = <NODE extends HTMLElement>(node: NODE) => node
+type NodeModifier<NODE> = (node: NODE) => HTMLElement | undefined
+
+/**
+ * Get node from reference.
+ * Example:
+ *
+ * ```
+ * const Foo:React.FC = () => {
+ *   const { ref, node } = useNodeRef()
+ *   console.log(node) // Div-node
+ *
+ *   return <div ref={ref}>...</div>
+ * }
+ * ```
+ *
+ * ```
+ * const ParentNode:React.FC = () => {
+ *   const { ref, node } = useNodeRef(() => node.parentNode)
+ *   console.log(node) // The parent-node of this node.
+ *
+ *   return <div ref={ref}>...</div>
+ * }
+ * ```
+ */
+const useNodeByReference = <NODE extends HTMLElement>(modifier: NodeModifier<NODE> = defaultNodeModifier) => {
+  const [ node, setNode ] = useState<HTMLElement | undefined>()
+  const ref = useCallback((node: NODE) => setNode(modifier(node)), [ setNode, modifier ])
+  return { ref, node }
+}
+
+export default useNodeByReference

--- a/src/app/features/shared/hooks/useNodeDimensions/useNodeDimensions.stories.tsx
+++ b/src/app/features/shared/hooks/useNodeDimensions/useNodeDimensions.stories.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { withKnobs, text } from "@storybook/addon-knobs"
+import styled from "styled-components"
+import { themeColor, themeSpacing } from "@datapunt/asc-ui"
+import useNodeByReference from "../useNodeByReference/useNodeByReference"
+import useNodeDimensions from "./useNodeDimensions"
+
+export default {
+  title: "Shared/Hooks/useNodeDimensions",
+  decorators: [withKnobs]
+}
+
+const Card = styled.div`
+  display: inline-block;
+  padding: 0 ${ themeSpacing(5) } ${ themeSpacing(5) } ${ themeSpacing(5) };
+  margin: ${ themeSpacing(5) } 0;
+  background-color: ${ themeColor("tint", "level3") }
+`
+
+export const Example: React.FC  = () => {
+  const { ref, node } = useNodeByReference<HTMLDivElement>()
+  const dimensions = useNodeDimensions(node)
+
+  return <>
+    <p>
+      Please change the content using the knobs below.
+    </p>
+    <div>
+      <Card ref={ref}>
+        <h4>Content</h4>
+        { text("content", "Lorem") }
+      </Card>
+    </div>
+    <div>
+      <pre>// Dimensions:</pre>
+      <pre>
+        {/*
+          IE11 cant seem to stringify the dimensions object.
+          That's why we unpack it manually here.
+        */}
+        { JSON.stringify({
+          x: dimensions?.x,
+          y: dimensions?.y,
+          width: dimensions?.width,
+          height:dimensions?.height,
+          top: dimensions?.top,
+          bottom: dimensions?.bottom
+        }, null, 2) }
+      </pre>
+    </div>
+  </>
+}
+
+

--- a/src/app/features/shared/hooks/useNodeDimensions/useNodeDimensions.tsx
+++ b/src/app/features/shared/hooks/useNodeDimensions/useNodeDimensions.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from "react"
+import ResizeObserver from "resize-observer-polyfill"
+
+/**
+ * Returns dimensions of the given node.
+ * Updates dimensions whenever the node changes its dimensions.
+ *
+ * Example usage:
+ * ```
+ * const Foo:React.FC = () => {
+ *   const { ref, node } = useNodeByReference()
+ *   const dimensions = useNodeDimensions(node)
+ *
+ *   console.log(dimensions)
+ *
+ *   return <div ref={ref}></div>
+ * }
+ *
+ * ```
+ *
+ *
+ */
+const useNodeDimensions = (node?: Element) => {
+  const [ dimensions, setDimensions ] = useState<DOMRectReadOnly>()
+
+  const resizeObserver = useMemo(() => new ResizeObserver(( entries ) => {
+    setDimensions(entries[0].contentRect as DOMRectReadOnly)
+  }), [ setDimensions ])
+
+  useEffect(() => {
+    if (node) {
+      resizeObserver.observe(node)
+    }
+
+    return () => {
+      if (node) {
+        resizeObserver.unobserve(node)
+      }
+    }
+  }, [node, resizeObserver])
+
+  return dimensions
+}
+
+export default useNodeDimensions


### PR DESCRIPTION
## The problem

Fixed columns are positioned absolute, and therefore do not follow the document-flow. [More info](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow).
We want to calculate the cell-height based on the row-height automatically.

![Screen Shot 2020-06-25 at 1 04 06 PM](https://user-images.githubusercontent.com/248906/85708760-cf9a0e00-b6e4-11ea-921d-e57754a5b68e.png)

## The solution

Introduced a hook to dynamically get the dimensions of a node-element.
The dimensions change whenever the node-element' dimensions change.

![dimensions](https://user-images.githubusercontent.com/248906/85708765-d163d180-b6e4-11ea-9bce-733ae89f346a.gif)

## Compatibility

We use the browser native `ResizeObserver`, which is available in all browsers (including Firefox 60), except IE11.
For IE11 we use a ponyfill that relies on `requestAnimationFrame`.

[Link to CanIUse](https://caniuse.com/#search=ResizeObserver)
[Link to polyfill](https://www.npmjs.com/package/resize-observer-polyfill)
