### PR TITLE
feat: add minWidth to columns to prevent loading-flickering and gain …

### DIFF
--- a/src/app/features/cases/components/organisms/CaseIndexTable/CaseIndexTable.tsx
+++ b/src/app/features/cases/components/organisms/CaseIndexTable/CaseIndexTable.tsx
@@ -9,7 +9,13 @@ import { ChevronRight } from "@datapunt/asc-assets/lib"
 const OpenButton: React.FC = () =>
   <Button variant="textButton" iconSize={14} iconLeft={<ChevronRight />}>Open</Button>
 
-const columns = ["Startdatum", "Einddatum", "Omschrijving", undefined]
+const columns = [
+  { header:"Startdatum", minWidth: 100 },
+  { header:"Einddatum", minWidth: 100 },
+  { header:"Omschrijving", minWidth: 300 },
+  { minWidth: 90 }
+]
+
 const mapData = (data: API.Case) => [
   data.startdatum,
   data.einddatum ?? "-",
@@ -25,7 +31,7 @@ const CaseIndexTable: React.FC = () => {
     columns={columns}
     data={mappedData}
     loading={data === undefined || isFetching}
-    fixedColumnWidth='90px'
+    hasFixedColumn={true}
   />)
 }
 

--- a/src/app/features/shared/components/atoms/Skeleton/SmallSkeleton.tsx
+++ b/src/app/features/shared/components/atoms/Skeleton/SmallSkeleton.tsx
@@ -23,8 +23,12 @@ const StyledDiv = styled.div<StyledDivProps>`
   animation: ${ backgroundAnimation } 4s linear infinite;   
 `
 
-const SmallSkeleton: React.FC = () => {
-  const width = useMemo(() => Math.round(Math.random() * 100 ) + 100, [])
+type Props = {
+  maxRandomWidth?: number
+}
+
+const SmallSkeleton: React.FC<Props> = ({ maxRandomWidth = 100 }) => {
+  const width = useMemo(() => Math.round(Math.random() * (maxRandomWidth - 50) ) + 50, [maxRandomWidth])
   return <StyledDiv width={width} />
 }
 

--- a/src/app/features/shared/components/molecules/Table/Table.stories.tsx
+++ b/src/app/features/shared/components/molecules/Table/Table.stories.tsx
@@ -11,13 +11,13 @@ export default {
 }
 
 const columns = [
-  "ID",
-  "First name",
-  "Surname",
-  "Email",
-  "Gender",
-  "Ip",
-  undefined
+  { header: "ID", minWidth: 100 },
+  { header: "First name", minWidth: 150 },
+  { header: "Surname", minWidth: 150 },
+  { header: "Email", minWidth: 300 },
+  { header: "Gender", minWidth: 150 },
+  { header: "Ip", minWidth: 200 },
+  { minWidth: 90 }
 ]
 
 const OpenButton: React.FC = () => <Button variant="textButton" iconSize={14} iconLeft={<ChevronRight />}>Open</Button>
@@ -78,7 +78,7 @@ export const ExampleWithFixedColumn = () =>
     <Table
       columns={columns}
       data={data}
-      fixedColumnWidth='90px'
+      hasFixedColumn={true}
     />
   </div>
 
@@ -89,7 +89,7 @@ export const ExampleWithLoading: React.FC = () =>
       columns={columns}
       data={data}
       loading={boolean("Loading", true)}
-      fixedColumnWidth='90px'
+      hasFixedColumn={true}
     />
   </div>
 

--- a/src/app/features/shared/components/molecules/Table/Table.test.tsx
+++ b/src/app/features/shared/components/molecules/Table/Table.test.tsx
@@ -7,7 +7,7 @@ import SmallSkeleton from "../../atoms/Skeleton/SmallSkeleton"
 import FixedTableCell from "./components/TableCell/FixedTableCell"
 
 describe("Table", () => {
-  const columns = ["column1", "column2"]
+  const columns = [{ header: "column1", minWidth: 100 }, { header: "column2", minWidth: 100 }]
   const data = [
     ["foo", "bar"],
     ["zoo", "baz"]
@@ -20,35 +20,20 @@ describe("Table", () => {
     })
 
     describe("when given fixedColumnWidth", () => {
-      it("should pass fixedColumnWidth to the last column", () => {
-        const component = mount(<Table data={data} columns={columns} fixedColumnWidth="100px" />)
+      it("should render fixed cells", () => {
+        const component = mount(<Table data={data} columns={columns} hasFixedColumn={true} />)
         const fixedCells = component.find(FixedTableCell)
 
         expect(fixedCells.length).toEqual(2)
-
-        expect(fixedCells.at(0).prop("fixedWidth")).toEqual("100px")
-        expect(fixedCells.at(0).text()).toEqual("bar")
-
-        expect(fixedCells.at(1).prop("fixedWidth")).toEqual("100px")
-        expect(fixedCells.at(1).text()).toEqual("baz")
       })
     })
   })
 
   describe("when loading", () => {
-    it("should render 30 SmallSkeletons", () => {
+    it("should render SmallSkeletons", () => {
       const component = mount(<Table data={data} columns={columns} loading={true} />)
       // 5 * 2 = numLoadingRows * numColumns
       expect(component.find(SmallSkeleton).length).toEqual(10)
-    })
-
-    describe("when given fixedColumnWidth", () => {
-      it("should NOT pass the fixedColumnWidth to the last column", () => {
-        const component = mount(<Table data={data} columns={columns} fixedColumnWidth="100px" loading={true} />)
-        const cells = component.find("[fixedWidth]")
-
-        expect(cells.length).toEqual(0)
-      })
     })
   })
 })

--- a/src/app/features/shared/components/molecules/Table/components/TableCell/FixedTableCell.tsx
+++ b/src/app/features/shared/components/molecules/Table/components/TableCell/FixedTableCell.tsx
@@ -6,7 +6,7 @@ import useNodeDimensions from "app/features/shared/hooks/useNodeDimensions/useNo
 import useNodeByReference from "app/features/shared/hooks/useNodeByReference/useNodeByReference"
 
 type StyledTDProps = {
-  fixedWidth?: string
+  width?: number
   height?: number
 }
 
@@ -19,12 +19,12 @@ const StyledTd = styled.td<StyledTDProps>`
   
   border-left: 1px solid ${ themeColor("tint", "level3") };
   
-  width: ${ props => props.fixedWidth ?? "auto" };
+  width: ${ props => `${ props.width }px;` ?? "auto" };     
   height: ${ props => `${ props.height }px;` ?? "auto" };     
 `
 
 type Props = {
-  fixedWidth?: string
+  width?: number
 }
 
 /**
@@ -35,13 +35,13 @@ type Props = {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
  */
-const FixedTableCell: React.FC<Props> = ({ children, fixedWidth }) => {
+const FixedTableCell: React.FC<Props> = ({ children, width }) => {
   // Grab parent node, a table-row element (TR).
   const { ref, node } = useNodeByReference<HTMLTableCellElement>(node => node?.parentElement ?? undefined)
   // Grab dimensions of the table-row.
   const dimensions = useNodeDimensions(node)
   // Pass height of the table-row.
-  return <StyledTd ref={ref} height={dimensions?.height} fixedWidth={fixedWidth}>
+  return <StyledTd ref={ref} height={dimensions?.height} width={width}>
     { children }
   </StyledTd>
 }

--- a/src/app/features/shared/components/molecules/Table/components/TableHeading/TableHeading.tsx
+++ b/src/app/features/shared/components/molecules/Table/components/TableHeading/TableHeading.tsx
@@ -2,7 +2,8 @@ import styled, { css } from "styled-components"
 import { themeColor, themeSpacing } from "@datapunt/asc-ui"
 
 type Props = {
-  fixedWidth?: string
+  isFixed?: boolean
+  minWidth?: number
 }
 
 const TableHeading = styled.th<Props>`     
@@ -10,11 +11,13 @@ const TableHeading = styled.th<Props>`
   border-bottom: 1px solid ${ themeColor("tint", "level5") };
   padding: ${ themeSpacing(2) } ${ themeSpacing(3) };
     
-  ${ ( { fixedWidth }: Props ) => fixedWidth && css`  
+  min-width: ${ props => props.minWidth ? `${ props.minWidth }px` : "auto" };  
+    
+  ${ props  => props.isFixed && css`  
       position: absolute;
       right: 0;
                 
-      width: ${ fixedWidth };
+      width: ${ props.minWidth ? `${ props.minWidth }px` : "auto" } };
   ` }   
 `
 


### PR DESCRIPTION
## The problem

No `minWidth` was set on the columns, causing the width of the columns to change on transition from loading to non-loading.

## The solution

Set a `minWidth` on columns:

![no loading flickering](https://user-images.githubusercontent.com/248906/85720438-bac37780-b6f0-11ea-89cc-3c2c7329f516.gif)
