### PR TITLE
feat: clean up edit form

### DIFF
--- a/src/app/features/cases/components/organisms/FormEdit/FormEdit.tsx
+++ b/src/app/features/cases/components/organisms/FormEdit/FormEdit.tsx
@@ -1,29 +1,25 @@
 import React from "react"
 import { ScaffoldForm, Alert } from "amsterdam-react-final-form"
 
-import { useGlobalActions, useGlobalState } from "app/state/state/globalState"
 import ScaffoldFields from "app/features/shared/components/molecules/Form/ScaffoldFields"
 
 import scaffoldProps from "./scaffold"
 
 type Props = {
+  errorMessage?: { detail: string }
+  hasError: boolean
+  onSubmit: (data: API.Case) => Promise<void>
+  isLoading: boolean
   caseDetails?: API.Case
 }
 
-const FormEdit: React.FC<Props> = ({ caseDetails }) => {
-  const {
-    cases: { errorMessage, hasError, isGetting: isGettingCases  },
-    caseTypes: { isGetting: isGettingCaseTypes }
-  } = useGlobalState()
-
-  const { cases: { update } } = useGlobalActions()
-
-  return (
+const FormEdit: React.FC<Props> = ({ isLoading, onSubmit, caseDetails, errorMessage, hasError }) => (
     <ScaffoldForm
-      showSpinner={ !caseDetails || isGettingCaseTypes || isGettingCases }
-      onSubmit={ update }
+      showSpinner={ isLoading }
+      onSubmit={ onSubmit }
       hasError={ hasError }
       initialValues={ caseDetails }
+      // TODO move these components to some sort of a message-system?
       successComponent={
         <Alert variant="success" title="Zaak succesvol gewijzigd!">
           Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
@@ -31,17 +27,13 @@ const FormEdit: React.FC<Props> = ({ caseDetails }) => {
       }
       errorComponent={
         <Alert variant="error" title="Kon de zaak niet opslaan!">
-          {
-            // @ts-ignore errorMessage is typed as string, while in reality its an object
-            errorMessage?.detail
-          }
+          { errorMessage?.detail }
         </Alert>
       }
     >
       <ScaffoldFields {...scaffoldProps} />
     </ScaffoldForm>
   )
-}
 
 
 export default FormEdit

--- a/src/app/features/cases/components/pages/edit/EditPage.tsx
+++ b/src/app/features/cases/components/pages/edit/EditPage.tsx
@@ -1,37 +1,29 @@
-import React, { useCallback } from "react"
+import React from "react"
 import { RouteComponentProps } from "@reach/router"
 import { FormTitle, Heading } from "@datapunt/asc-ui"
 import { TrashBin } from "@datapunt/asc-assets/lib"
 
-import { useGlobalActions, useGlobalState } from "app/state/state/globalState"
 import DefaultLayout from "app/features/shared/components/layouts/DefaultLayout/DefaultLayout"
 import ActionButtonWrap from "app/features/shared/components/atoms/ActionButtonWrap/ActionButtonWrap"
 import ConfirmButton from "app/features/shared/components/molecules/ConfirmButton/ConfirmButton"
 
 import FormEdit from "app/features/cases/components/organisms/FormEdit/FormEdit"
-import { useCaseByUUID } from "app/features/cases/hooks/useCaseByUUID"
+
+import { useEditPage } from "./hooks/useEditPage"
 
 type Props = {
   uuid: API.Case["uuid"]
 }
 
 const EditPage: React.FC<RouteComponentProps<Props>> = ({ uuid }) => {
-  const {
-    cases: { isGetting: isGettingCases  },
-    caseTypes: { isGetting: isGettingCaseTypes }
-  } = useGlobalState()
-
-  const { cases: { del } } = useGlobalActions()
-  const { caseDetails } = useCaseByUUID(uuid!)
-
-  const handleDelete = useCallback(() => del(caseDetails!), [ caseDetails, del ])
+  const { handleDelete, caseDetails, isLoading, hasError, errorMessage, handleUpdate } = useEditPage(uuid)
 
   return (
     <DefaultLayout>
-      <Heading>Aanpassen zaak:  { uuid }</Heading>
+      <Heading>Aanpassen zaak</Heading>
       <ActionButtonWrap>
         <ConfirmButton
-          disabled={ !caseDetails || isGettingCaseTypes || isGettingCases }
+          disabled={isLoading}
           onConfirm={handleDelete}
           iconLeft={<TrashBin />}
           variant="secondary"
@@ -42,7 +34,13 @@ const EditPage: React.FC<RouteComponentProps<Props>> = ({ uuid }) => {
         </ConfirmButton>
       </ActionButtonWrap>
       <FormTitle>Gebruik dit formulier een zaak te wijzigen</FormTitle>
-      <FormEdit caseDetails={caseDetails} />
+      <FormEdit
+        errorMessage={errorMessage as unknown as { detail: string }}
+        hasError={hasError}
+        onSubmit={handleUpdate}
+        isLoading={isLoading}
+        caseDetails={caseDetails}
+      />
     </DefaultLayout>
   )
 }

--- a/src/app/features/cases/components/pages/edit/hooks/useEditPage.ts
+++ b/src/app/features/cases/components/pages/edit/hooks/useEditPage.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react"
+import { useGlobalActions, useGlobalState } from "app/state/state/globalState"
+
+export const useEditPage = (uuid?: API.Case["uuid"]) => {
+  // Get the info we need from the state:
+  const {
+    cases: { errorMessage, hasError, isGetting: isGettingCases, data  },
+    caseTypes: { isGetting: isGettingCaseTypes }
+  } = useGlobalState()
+  // Get actions
+  const {
+    cases: { update: handleUpdate, del }
+  } = useGlobalActions()
+
+  // Find caseDetails
+  const caseDetails = data?.find(caseDetails => caseDetails.uuid === uuid)
+  // Define handleDelete callback
+  const handleDelete = useCallback(() => del(caseDetails!), [ caseDetails, del ])
+  // Are we still loading?
+  const isLoading = isGettingCaseTypes || isGettingCases
+
+  return {
+    errorMessage,
+    hasError,
+    isLoading,
+    handleUpdate,
+    handleDelete,
+    caseDetails
+  }
+}


### PR DESCRIPTION
Both edit-form and edit-page took stuff from the state.
Now only edit-page does it.

TODO:
- implement some sort of message system
- get rid of either CreateForm or EditForm as they are almost identical