### PR TITLE
feat: show flash messages onDelete and onEdit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10711,9 +10711,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globalstate-hooks": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/globalstate-hooks/-/globalstate-hooks-0.1.8.tgz",
-      "integrity": "sha512-odhN4cN+xWb2SYMEm0mXhyBGB4Jrwd7ljjJPac1UhgRVLezvWoUMBApgSW8/RQ82kh/o1Z6xzeb/uuvH5SHmhA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/globalstate-hooks/-/globalstate-hooks-0.1.9.tgz",
+      "integrity": "sha512-8FyQyuqTLmhwFR4zijTZzzzWKBhK356jF6aWTeh8Mo5YLTPOlMjw2r92FOgdorkE696ZjfuiLW+fVQ/J8Of/Pg==",
       "requires": {
         "deepmerge": "^4.2.2",
         "immer": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dotenv-flow": "^3.2.0",
     "final-form": "^4.20.0",
     "final-form-arrays": "^3.0.2",
-    "globalstate-hooks": "^0.1.8",
+    "globalstate-hooks": "^0.1.9",
     "immer": "^6.0.9",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,23 @@
 import React from "react"
 import { ThemeProvider, GlobalStyle } from "@datapunt/asc-ui"
+import { LocationProvider } from "@reach/router"
 
 import Router from "app/features/shared/routing/Router"
 import GlobalStateProvider from "app/state/state/GlobalStateProvider"
+import FlashMessageProvider from "app/state/flashMessages/FlashMessageProvider"
 import Debug from "./app/state/state/Debug"
 
 const App: React.FC = () => (
   <ThemeProvider>
     <GlobalStyle />
-    <GlobalStateProvider>
-      <Router />
-      { process.env.REACT_APP_DEBUG_MODE && 
-        <Debug />
-      }
-    </GlobalStateProvider>
+    <LocationProvider>
+      <GlobalStateProvider>
+        <FlashMessageProvider>
+          <Router />
+          { process.env.REACT_APP_DEBUG_MODE && <Debug /> }
+        </FlashMessageProvider>
+      </GlobalStateProvider>
+    </LocationProvider>
   </ThemeProvider>
 )
 

--- a/src/app/features/cases/components/organisms/FormCreate/FormCreate.tsx
+++ b/src/app/features/cases/components/organisms/FormCreate/FormCreate.tsx
@@ -1,34 +1,22 @@
 import React from "react"
-import { ScaffoldForm, Alert } from "amsterdam-react-final-form"
+import { ScaffoldForm } from "amsterdam-react-final-form"
 
-import { useGlobalState, useGlobalActions } from "app/state/state/globalState"
-
+import to from "app/features/shared/routing/to"
 import ScaffoldFields from "app/features/shared/components/molecules/Form/ScaffoldFields"
+import { useCrudCreate } from "app/features/shared/hooks/useCrud/useCrud"
 
 import scaffoldProps from "./scaffold"
 
 const FormCreate: React.FC = () => {
-  const { cases: { errorMessage, hasError  } } = useGlobalState()
-  const { cases: { create } } = useGlobalActions()
+  const handleCreate = useCrudCreate({
+    stateKey: "cases",
+    redirectTo: to("/cases"),
+    success: { title: "Zaak aangemaakt", body: "De zaak is succesvol aangemaakt" },
+    error: { title: "Kon zaak niet aanmaken" }
+  })
 
   return (
-    <ScaffoldForm
-      onSubmit={ create }
-      hasError={ hasError }
-      successComponent={
-        <Alert variant="success" title="Zaak succesvol aangemaakt!">
-          Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
-        </Alert>
-      }
-      errorComponent={
-        <Alert variant="error" title="Kon zaak niet aanmaken!">
-          {
-            // @ts-ignore errorMessage is typed as string, while in reality its an object
-            errorMessage?.detail
-          }
-        </Alert>
-      }
-    >
+    <ScaffoldForm onSubmit={ handleCreate }>
       <ScaffoldFields {...scaffoldProps} />
     </ScaffoldForm>
   )

--- a/src/app/features/cases/components/organisms/FormEdit/FormEdit.tsx
+++ b/src/app/features/cases/components/organisms/FormEdit/FormEdit.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ScaffoldForm, Alert } from "amsterdam-react-final-form"
+import { ScaffoldForm } from "amsterdam-react-final-form"
 
 import ScaffoldFields from "app/features/shared/components/molecules/Form/ScaffoldFields"
 
@@ -13,23 +13,11 @@ type Props = {
   caseDetails?: API.Case
 }
 
-const FormEdit: React.FC<Props> = ({ isLoading, onSubmit, caseDetails, errorMessage, hasError }) => (
+const FormEdit: React.FC<Props> = ({ isLoading, onSubmit, caseDetails }) => (
     <ScaffoldForm
       showSpinner={ isLoading }
       onSubmit={ onSubmit }
-      hasError={ hasError }
       initialValues={ caseDetails }
-      // TODO move these components to some sort of a message-system?
-      successComponent={
-        <Alert variant="success" title="Zaak succesvol gewijzigd!">
-          Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
-        </Alert>
-      }
-      errorComponent={
-        <Alert variant="error" title="Kon de zaak niet opslaan!">
-          { errorMessage?.detail }
-        </Alert>
-      }
     >
       <ScaffoldFields {...scaffoldProps} />
     </ScaffoldForm>

--- a/src/app/features/cases/components/pages/edit/hooks/useEditPage.ts
+++ b/src/app/features/cases/components/pages/edit/hooks/useEditPage.ts
@@ -1,23 +1,42 @@
-import { useCallback } from "react"
-import { useGlobalActions, useGlobalState } from "app/state/state/globalState"
+import { useGlobalState } from "app/state/state/globalState"
+
+import to from "app/features/shared/routing/to"
+import { useCrudUpdate, useCrudDelete } from "app/features/shared/hooks/useCrud/useCrud"
 
 export const useEditPage = (uuid?: API.Case["uuid"]) => {
-  // Get the info we need from the state:
   const {
     cases: { errorMessage, hasError, isGetting: isGettingCases, data  },
     caseTypes: { isGetting: isGettingCaseTypes }
   } = useGlobalState()
-  // Get actions
-  const {
-    cases: { update: handleUpdate, del }
-  } = useGlobalActions()
 
   // Find caseDetails
   const caseDetails = data?.find(caseDetails => caseDetails.uuid === uuid)
-  // Define handleDelete callback
-  const handleDelete = useCallback(() => del(caseDetails!), [ caseDetails, del ])
-  // Are we still loading?
-  const isLoading = isGettingCaseTypes || isGettingCases
+
+  const handleUpdate = useCrudUpdate({
+    stateKey: "cases",
+    redirectTo: to("/cases"),
+    success: {
+      title: "Succesvol gewijzigd",
+      body: "De zaak is succesvol gewijzigd"
+    },
+    error: {
+      title: "Kon niet wijzigen"
+    }
+  })
+
+  const handleDelete = useCrudDelete(caseDetails!, {
+    stateKey: "cases",
+    redirectTo: to("/cases"),
+    success: {
+      title: "Succesvol verwijderd",
+      body: "De zaak is succesvol verwijderd"
+    },
+    error: {
+      title: "Kon niet verwijderen"
+    }
+  })
+
+  const isLoading = !caseDetails || isGettingCaseTypes || isGettingCases
 
   return {
     errorMessage,

--- a/src/app/features/cases/components/pages/home/HomePage.tsx
+++ b/src/app/features/cases/components/pages/home/HomePage.tsx
@@ -1,6 +1,14 @@
-import React from "react"
-import { Redirect, RouteComponentProps } from "@reach/router"
+import React, { useEffect } from "react"
+import { navigate, RouteComponentProps } from "@reach/router"
 
-const HomePage: React.FC<RouteComponentProps> = () => (<Redirect to="/cases" />)
+import to from "app/features/shared/routing/to"
+
+const HomePage: React.FC<RouteComponentProps> = () => {
+  // <Redirect to={to("/cases")} /> sometimes throws errors:
+  // @see https://github.com/reach/router/issues/100#issuecomment-414312284
+
+  useEffect(() => { navigate(to("/cases"), { replace: true }) }, [])
+  return null
+}
 
 export default HomePage

--- a/src/app/features/shared/components/atoms/SpinnerButton/SpinnerButton.tsx
+++ b/src/app/features/shared/components/atoms/SpinnerButton/SpinnerButton.tsx
@@ -1,19 +1,23 @@
 import React, { useCallback, useState } from "react"
 import { Button } from "@datapunt/asc-ui"
 import Spinner from "@datapunt/asc-ui/lib/components/Spinner"
+import useIsMounted from "../../../hooks/useIsMounted/useIsMounted"
 
 type Props = Omit<React.ComponentProps<typeof Button>, "onClick"> & {
   onClick: () => Promise<any>
 }
 
 const SpinnerButton: React.FC<Props> = ({ onClick, ...restProps }) => {
+  const isMounted = useIsMounted()
   const [isSpinning, setIsSpinning] = useState(false)
 
   const handleClick = useCallback(async () => {
     setIsSpinning(true)
     await onClick()
-    setIsSpinning(false)
-  }, [ onClick ])
+    if (isMounted.current) {
+      setIsSpinning(false)
+    }
+  }, [ onClick, isMounted ])
 
   return (
     <Button onClick={handleClick} icon={ isSpinning ? <Spinner /> : undefined } {...restProps} />

--- a/src/app/features/shared/components/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/app/features/shared/components/layouts/DefaultLayout/DefaultLayout.tsx
@@ -4,6 +4,7 @@ import { Header } from "@datapunt/asc-ui"
 import DefaultNavigation from "app/features/shared/components/organisms/navigation/DefaultNavigation"
 import { MainWrapper } from "app/features/shared/components/atoms/MainWrapper/MainWrapper"
 import to from "app/features/shared/routing/to"
+import FlashMessages from "app/features/shared/components/molecules/FlashMessages/FlashMessages"
 
 const DefaultLayout: React.FC = ({ children }) => (
   <>
@@ -14,6 +15,7 @@ const DefaultLayout: React.FC = ({ children }) => (
       navigation={<DefaultNavigation />}
     />
     <MainWrapper>
+      <FlashMessages />
       { children }
     </MainWrapper>
   </>

--- a/src/app/features/shared/components/molecules/FlashMessages/FlashMessages.tsx
+++ b/src/app/features/shared/components/molecules/FlashMessages/FlashMessages.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { useLocation } from "@reach/router"
+
+import { useFlashMessages } from "app/state/flashMessages/useFlashMessages"
+import Alert from "amsterdam-react-final-form/components/unbound/Alert"
+
+const FlashMessages: React.FC = () => {
+  const { pathname } = useLocation()
+  const { state } = useFlashMessages()
+
+  return (
+    <>
+      {state[pathname] && state[pathname].map((props, index) => <Alert key={index} {...props} />)}
+    </>
+  )
+}
+
+export default FlashMessages

--- a/src/app/features/shared/hooks/useCrud/useCrud.ts
+++ b/src/app/features/shared/hooks/useCrud/useCrud.ts
@@ -1,0 +1,60 @@
+import { useCallback } from "react"
+import { navigate, useLocation } from "@reach/router"
+
+import { useGlobalActions } from "app/state/state/globalState"
+import { useFlashMessages } from "app/state/flashMessages/useFlashMessages"
+
+type GlobalActions = ReturnType<typeof useGlobalActions>
+
+type Config = {
+  stateKey: keyof GlobalActions
+  redirectTo: string
+  success: {
+    title: string
+    body: string
+  }
+  error: {
+    title: string
+  }
+}
+
+/**
+ * - Calls a state action ("update", "create" or "del")
+ * - Adds a flashMessage on either success or server-error
+ * - Redirects on success.
+ */
+const useCrud = (
+  config: Config,
+  action: "update" | "create" | "del",
+  toDelete?: any // TODO can I type this? Or refactor to be able to use an id-string?
+) => {
+  const {
+    redirectTo,
+    stateKey,
+    success: { title: successTitle, body: successBody },
+    error: { title: errorTitle }
+  } = config
+
+  const { pathname } = useLocation()
+  const globalActions = useGlobalActions()
+  const { addSuccessFlashMessage, addErrorFlashMessage } = useFlashMessages()
+
+  const handleAction = globalActions[stateKey][action]
+
+  return useCallback(async (item?) => {
+    try {
+      // Actually call the action: (either, `update`, `create` or `del`)
+      await handleAction(action === "del" ? toDelete : item)
+      addSuccessFlashMessage(redirectTo, successTitle, successBody)
+      return navigate(redirectTo)
+    } catch(e) {
+      console.error(`${ action } ${ config.stateKey } failed!`, e)
+      // Something went wrong! Set flash message
+      addErrorFlashMessage(pathname, errorTitle, e.detail)
+    }
+  }, [handleAction, action, toDelete, addSuccessFlashMessage, redirectTo, successTitle, successBody, config.stateKey, addErrorFlashMessage, pathname, errorTitle])
+}
+
+export const useCrudUpdate = (config: Config) => useCrud(config, "update")
+export const useCrudCreate = (config: Config) => useCrud(config, "create")
+export const useCrudDelete = (toDelete: any, config: Config) => useCrud(config, "del", toDelete)

--- a/src/app/features/shared/hooks/useIsMounted/useIsMounted.ts
+++ b/src/app/features/shared/hooks/useIsMounted/useIsMounted.ts
@@ -1,0 +1,15 @@
+import { useRef, useEffect } from "react"
+
+/**
+ * Returns a RefObject, the current value is true when the component is still mounted
+ */
+const useIsMounted = () => {
+  const isMounted = useRef(false)
+  useEffect(() => {
+    isMounted.current = true
+    return () => { isMounted.current = false }
+  }, [])
+  return isMounted
+}
+
+export default useIsMounted

--- a/src/app/state/flashMessages/FlashMessageProvider.tsx
+++ b/src/app/state/flashMessages/FlashMessageProvider.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+import { useFlashMessagesReducer } from "./useFlashMessagesReducer"
+
+export type Context = ReturnType<typeof useFlashMessagesReducer>
+export const FlashMessageContext = React.createContext<Context|undefined>(undefined)
+
+const FlashMessageProvider: React.FC = ({ children }) => {
+  const value = useFlashMessagesReducer()
+  return (
+    <FlashMessageContext.Provider value={value}>
+      { children }
+    </FlashMessageContext.Provider>
+  )
+}
+export default FlashMessageProvider

--- a/src/app/state/flashMessages/useFlashMessages.tsx
+++ b/src/app/state/flashMessages/useFlashMessages.tsx
@@ -1,0 +1,22 @@
+import { useContext } from "react"
+import { FlashMessageContext } from "./FlashMessageProvider"
+
+/**
+ * A flash message is a message that is only shown once.
+ * Once the message is shown on a route, and the user navigates away from that route, the message is cleared.
+ * (The term "flash-message" comes from backend frameworks such as Django and Symfony).
+ *
+ * Example usage:
+ * const { addSuccessFlashMessage } = useFlashMessages()
+ *
+ *
+ * addSuccessFlashMessage("/cases", "Succesvol verwijderd", "De zaak is succesvol verwijderd" })
+ *
+ */
+export const useFlashMessages = () => {
+  const context = useContext(FlashMessageContext)
+  if (context === undefined) {
+    throw new Error("Context was not set")
+  }
+  return context
+}

--- a/src/app/state/flashMessages/useFlashMessagesReducer.ts
+++ b/src/app/state/flashMessages/useFlashMessagesReducer.ts
@@ -1,0 +1,67 @@
+import React, { useCallback, useEffect, useReducer } from "react"
+import { globalHistory, useLocation } from "@reach/router"
+import produce from "immer"
+import { Alert } from "amsterdam-react-final-form"
+
+export type FlashMessage = React.ComponentProps<typeof Alert>
+export type State = Record<string, FlashMessage[]>
+
+type Action =
+  | { type: "add", path: string, props: FlashMessage }
+  | { type: "clear", path: string }
+
+export const reducer = produce((draft, action: Action) => {
+  if (draft[action.path] === undefined) {
+    draft[action.path] = []
+  }
+  switch (action.type) {
+    case "add":
+      draft[action.path].push(action.props)
+      break
+    case "clear":
+      delete draft[action.path]
+      break
+  }
+})
+
+///////////////////////////////////////////////////////////////////////////////////////////
+
+export const useFlashMessagesReducer = () => {
+  const [state, dispatch] = useReducer(reducer, {} as State)
+  const { pathname } = useLocation()
+
+  const clearFlashMessages = useCallback(
+    (path: string) => dispatch({ type: "clear", path }),
+    [dispatch]
+  )
+
+  const addSuccessFlashMessage = useCallback(
+    (path: string, title: string, body?: string | JSX.Element) => dispatch({
+      path,
+      type: "add",
+      props: { title, children: body, variant: "success" }
+    }),
+    [dispatch]
+  )
+
+  const addErrorFlashMessage = useCallback(
+    (path: string, title: string, body?: string | JSX.Element) => dispatch({
+      path,
+      type: "add",
+      props: { title, children: body, variant: "error" }
+    }),
+    [dispatch]
+  )
+
+  useEffect(() => {
+    const unListen = globalHistory.listen(() => clearFlashMessages(pathname))
+    return () => { unListen() }
+  }, [ pathname, clearFlashMessages ])
+
+  return {
+    state: state as State,
+    addSuccessFlashMessage,
+    addErrorFlashMessage,
+    clearFlashMessages
+  }
+}


### PR DESCRIPTION
Adds flashMessages for C(R)UD actions.

- Calls a state action ("update", "create" or "del")
- Adds a flashMessage on either success or server-error
- Redirects on success.

Example:
```
const handleUpdate = useCrudUpdate({
    stateKey: "cases",
    redirectTo: to("/cases"),
    success: {
      title: "Succesvol gewijzigd",
      body: "De zaak is succesvol gewijzigd"
    },
    error: {
      title: "Kon niet wijzigen"
    }
  })
```
