### PR TITLE
feat: group queue and cache on ApiProvider level

### DIFF
--- a/src/app/state/rest/hooks/useApiCache.test.ts
+++ b/src/app/state/rest/hooks/useApiCache.test.ts
@@ -4,25 +4,23 @@ import { useApiCache } from "./useApiCache"
 describe("useApiCache", () => {
   it("should return undefined when an item was not set", () => {
     const { result } = renderHook(() => useApiCache())
-    expect(result.current.getCacheItem("group", "my/path")).toEqual(undefined)
+    expect(result.current.getCacheItem("my/path")).toEqual(undefined)
   })
 
   it("should be able to set an item", () => {
     const { result } = renderHook(() => useApiCache())
     act(() => {
-      result.current.setCacheItem("group", "my/path", { foo: "bar" })
+      result.current.setCacheItem("my/path", { foo: "bar" })
     })
-    expect(result.current.getCacheItem("group", "my/path")).toEqual({ foo: "bar" })
+    expect(result.current.getCacheItem("my/path")).toEqual({ foo: "bar" })
   })
 
   it("should be able to clear a group", () => {
     const { result } = renderHook(() => useApiCache())
     act(() => {
-      result.current.setCacheItem("group1", "my/path", { foo: "group1" })
-      result.current.setCacheItem("group2", "my/path", { foo: "group2" })
-      result.current.clearCache("group1")
+      result.current.setCacheItem("my/path", { foo: "group1" })
+      result.current.clearCache()
     })
-    expect(result.current.getCacheItem("group1", "my/path")).toEqual(undefined)
-    expect(result.current.getCacheItem("group2", "my/path")).toEqual({ foo: "group2" })
+    expect(result.current.getCacheItem("my/path")).toEqual(undefined)
   })
 })

--- a/src/app/state/rest/hooks/useApiCache.ts
+++ b/src/app/state/rest/hooks/useApiCache.ts
@@ -1,33 +1,31 @@
 import { useCallback, useReducer } from "react"
 
 export type ApiCache = {
-  getCacheItem: (group: string, url: string) => any
-  setCacheItem: (key: string, group: string, value: any) => void
-  clearCache: (group: string) => void
+  getCacheItem: (key: string) => any
+  setCacheItem: (key: string, value: any) => void
+  clearCache: () => void
 }
 
 type State = Record<string, any>
 type Action =
-  | { type: "SET_ITEM", key: string, group: string, value: any }
-  | { type: "CLEAR", group: string }
+  | { type: "SET_ITEM", key: string, value: any }
+  | { type: "CLEAR" }
 
 const reducer = (state: State, action: Action) => {
   switch(action.type) {
     case "SET_ITEM":
-      return { ...state, [`${ action.group }__${ action.key }`]: action.value }
+      return { ...state, [action.key]: action.value }
     case "CLEAR":
-      return Object.entries(state)
-        .filter(([key]) => !key.startsWith(action.group))
-        .reduce((acc, [key, val]) => ({ ...acc, [key]: val }), {})
+      return {}
   }
 }
 
 export const useApiCache = (): ApiCache => {
   const [ cache, dispatch ] = useReducer(reducer, {})
 
-  const getCacheItem = useCallback((group: string, url: string) => cache[`${ group }__${ url }`], [ cache ])
-  const setCacheItem = useCallback((group: string, key: string, value: any) => dispatch({ type: "SET_ITEM", group, key, value }), [ dispatch ])
-  const clearCache = useCallback((group: string) => dispatch({ type: "CLEAR", group }), [ dispatch ])
+  const getCacheItem = useCallback((url: string) => cache[url], [ cache ])
+  const setCacheItem = useCallback((key: string, value: any) => dispatch({ type: "SET_ITEM", key, value }), [ dispatch ])
+  const clearCache = useCallback(() => dispatch({ type: "CLEAR" }), [ dispatch ])
 
   return { getCacheItem, setCacheItem, clearCache }
 }

--- a/src/app/state/rest/hooks/useApiRequest.test.tsx
+++ b/src/app/state/rest/hooks/useApiRequest.test.tsx
@@ -12,7 +12,7 @@ type Pet = {
 describe("useApiRequest", () => {
   it("should perform a GET request on mount", async () => {
     const getHeaders = jest.fn()
-    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "pet", getHeaders })
+    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "cases", getHeaders })
 
     // Define nock scope:
     const scope = nock("http://localhost")
@@ -38,7 +38,7 @@ describe("useApiRequest", () => {
   })
 
   it("should NOT perform duplicate requests", async () => {
-    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "pet" })
+    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "cases" })
 
     const scope = nock("http://localhost")
       .get("/pet")
@@ -89,7 +89,7 @@ describe("useApiRequest", () => {
       (hook: any, onSuccess: () => void) => hook.execDelete(onSuccess)
     ]
   ])("should re-execute a GET after a %s", async (method, prepareScope, exec) => {
-    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "pet" })
+    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "cases" })
 
     const scope = nock("http://localhost")
       .get("/pet")
@@ -126,7 +126,7 @@ describe("useApiRequest", () => {
 
   it("should call the error handler when a error occurs", async () => {
     const handleError = jest.fn()
-    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "pet", handleError })
+    const usePet = () => useApiRequest<Pet>({ url: "http://localhost/pet", groupName: "cases", handleError })
 
     const scope = nock("http://localhost")
       .get("/pet")

--- a/src/app/state/rest/hooks/useApiRequest.ts
+++ b/src/app/state/rest/hooks/useApiRequest.ts
@@ -2,10 +2,11 @@ import axios, { AxiosError, Method } from "axios"
 import { useCallback, useEffect, useContext } from "react"
 
 import { ApiContext } from "../provider/ApiProvider"
+import { ApiGroup } from "../index"
 
 type Config = {
   url: string
-  groupName: string
+  groupName: ApiGroup
   handleError?: ( error: AxiosError ) => void
   getHeaders?: () => Record<string, string>
 }
@@ -19,7 +20,7 @@ const useApiRequest = <Schema, Payload = Partial<Schema>>({ url, groupName, hand
     clearCache,
     pushRequest,
     isPendingRequest
-  } = useContext(ApiContext)
+  } = useContext(ApiContext)[groupName]
 
   /**
    * Executes an API request
@@ -34,9 +35,9 @@ const useApiRequest = <Schema, Payload = Partial<Schema>>({ url, groupName, hand
       })
 
       if (method !== "get") {
-        clearCache(groupName)
+        clearCache()
       } else {
-        setCacheItem(groupName, url, response.data)
+        setCacheItem(url, response.data)
       }
       if (onSuccess) {
         onSuccess()
@@ -46,7 +47,7 @@ const useApiRequest = <Schema, Payload = Partial<Schema>>({ url, groupName, hand
         handleError(error)
       }
     }
-  }, [clearCache, setCacheItem, url, groupName, handleError, getHeaders])
+  }, [clearCache, setCacheItem, url, handleError, getHeaders])
 
   /**
    * Queues an API request
@@ -65,7 +66,7 @@ const useApiRequest = <Schema, Payload = Partial<Schema>>({ url, groupName, hand
   const execDelete = useCallback((onSuccess?: Callback) => queueRequest("delete", undefined, onSuccess), [ queueRequest ])
 
   // reFetch whenever our cache is invalidated
-  const data = getCacheItem(groupName, url) as Schema
+  const data = getCacheItem(url) as Schema
   useEffect(() => {
     if (!data) { execGet() }
   }, [ execGet, data ])

--- a/src/app/state/rest/index.ts
+++ b/src/app/state/rest/index.ts
@@ -1,10 +1,15 @@
 import useApiRequest from "./hooks/useApiRequest"
-import { useErrorHandler, makeGatewayUrl, getHeaders } from "./hooks/utils/utils"
+import { getHeaders, makeGatewayUrl, useErrorHandler } from "./hooks/utils/utils"
 
 type APIListResponse<T> = {
   count: number
   results: T[]
 }
+
+export type ApiGroup =
+  | "cases"
+  | "caseTypes"
+  | "caseStates"
 
 /**
  * Please configure your endpoints here:
@@ -34,7 +39,7 @@ export const useCaseTypes = () => {
   const handleError = useErrorHandler()
   return useApiRequest<APIListResponse<API.CaseType>>({
     url: makeGatewayUrl("case-types"),
-    groupName: "case-types",
+    groupName: "caseTypes",
     handleError,
     getHeaders
   })
@@ -45,7 +50,7 @@ export const useCaseStates = () => {
   // TODO fix when API.CaseState is reintroduced
   return useApiRequest<APIListResponse<any>>({
     url: makeGatewayUrl("states"),
-    groupName: "case-states",
+    groupName: "caseStates",
     handleError,
     getHeaders
   })

--- a/src/app/state/rest/provider/ApiProvider.tsx
+++ b/src/app/state/rest/provider/ApiProvider.tsx
@@ -1,22 +1,35 @@
 import React from "react"
+
 import { ApiCache, useApiCache } from "../hooks/useApiCache"
 import { RequestQueue, useRequestQueue } from "../hooks/useRequestQueue"
+import { noopContext } from "./noopContext"
 
-const noopUndefined = () => undefined
-const noopBoolean = () => false
-export const ApiContext = React.createContext<ApiCache & RequestQueue>({
-  isPendingRequest: noopBoolean,
-  pushRequest: noopUndefined,
-  getCacheItem: noopUndefined,
-  setCacheItem: noopUndefined,
-  clearCache: noopUndefined
+import { ApiGroup } from "../index"
+
+type GroupedContext = Record<ApiGroup, ApiCache & RequestQueue>
+export const ApiContext = React.createContext<GroupedContext>({
+  cases: noopContext,
+  caseTypes: noopContext,
+  caseStates: noopContext
 })
 
 const ApiProvider: React.FC = ({ children }) => {
-  const cache = useApiCache()
-  const queue = useRequestQueue()
+  const value: GroupedContext = {
+    cases: {
+      ...useApiCache(),
+      ...useRequestQueue()
+    },
+    caseTypes: {
+      ...useApiCache(),
+      ...useRequestQueue()
+    },
+    caseStates: {
+      ...useApiCache(),
+      ...useRequestQueue()
+    }
+  }
 
-  return <ApiContext.Provider value={{ ...cache, ...queue }}>
+  return <ApiContext.Provider value={value}>
     {children}
   </ApiContext.Provider>
 }

--- a/src/app/state/rest/provider/noopContext.ts
+++ b/src/app/state/rest/provider/noopContext.ts
@@ -1,0 +1,13 @@
+import { ApiCache } from "../hooks/useApiCache"
+import { RequestQueue } from "../hooks/useRequestQueue"
+
+const noopUndefined = () => undefined
+const noopBoolean = () => false
+
+export const noopContext: ApiCache & RequestQueue = {
+  isPendingRequest: noopBoolean,
+  pushRequest: noopUndefined,
+  getCacheItem: noopUndefined,
+  setCacheItem: noopUndefined,
+  clearCache: noopUndefined
+}


### PR DESCRIPTION
# Simplified grouping

`useRequestQueue` and `useApiCache` are now grouped on the Provider level.
`useApiRequest` just grabs its methods from the group in the Provider.

# Why

- No need to pass along the group anymore.
- `useRequestQueue` is now grouped 'for free'.
- `useApiCache` and `useRequestQueue` don't now anything about groups anymore

