### PR TITLE
chore: bump version amsterdam-react-final-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7629,21 +7629,16 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amsterdam-react-final-form": {
-      "version": "0.1.88",
-      "resolved": "https://registry.npmjs.org/amsterdam-react-final-form/-/amsterdam-react-final-form-0.1.88.tgz",
-      "integrity": "sha512-EsR0MZW68jOMqpL8t/W/AVCk07In+x/Yi8tnF2DMUGcgjjS3oysFOpDXH7ofEs36AXGGKmeOhBUzlqWrmSgt8A==",
+      "version": "0.1.98",
+      "resolved": "https://registry.npmjs.org/amsterdam-react-final-form/-/amsterdam-react-final-form-0.1.98.tgz",
+      "integrity": "sha512-CofMKuFUzQFp8Oo3wUHrHuV8AdnY4zqSZUJ2j3PKT/NQMSJxqpCAhJXq0xWBYYRzZY9miFknDy/BfSEGYmqVZA==",
       "requires": {
-        "@datapunt/asc-assets": "^0.20.0",
         "@datapunt/asc-ui": "^0.20.0",
-        "final-form": "^4.19.1",
+        "final-form": "^4.20.1",
         "final-form-arrays": "^3.0.2",
         "lodash.isequal": "^4.5.0",
-        "objectFitPolyfill": "^2.3.0",
-        "react-app-polyfill": "^1.0.6",
-        "react-final-form": "^6.4.0",
-        "react-final-form-arrays": "^3.1.1",
-        "react-scripts": "3.4.1",
-        "styled-components": "^5.1.0"
+        "react-final-form": "^6.5.1",
+        "react-final-form-arrays": "^3.1.2"
       },
       "dependencies": {
         "@datapunt/asc-assets": {
@@ -18254,7 +18249,8 @@
     "objectFitPolyfill": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.0.tgz",
-      "integrity": "sha512-VgF98xGs2upBxO6a4FKGEEip5kXQCYpIwrKSDQ6oyFvPAmTrm6nPD/Y/IetoHx62HE6N82hWvc7Tc0evEBkoyA=="
+      "integrity": "sha512-VgF98xGs2upBxO6a4FKGEEip5kXQCYpIwrKSDQ6oyFvPAmTrm6nPD/Y/IetoHx62HE6N82hWvc7Tc0evEBkoyA==",
+      "optional": true
     },
     "objectorarray": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/styled-components": "^5.1.1",
-    "amsterdam-react-final-form": "^0.1.88",
+    "amsterdam-react-final-form": "^0.1.98",
     "amsterdam-scaffold-form": "^0.1.27",
     "axios": "^0.20.0",
     "dotenv-flow": "^3.2.0",


### PR DESCRIPTION
fixes npm peer dependency warnings