### PR TITLE
Update GitHub Action node-version to package specification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install


### PR DESCRIPTION
Should fix this pipeline/integration warning (also in `zaken-backend` integration tests, which is where I noticed it):

```
Run npm install
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'zaken-frontend@1.0.56',
npm warn EBADENGINE   required: { node: '>=22', npm: '>=10' },
npm warn EBADENGINE   current: { node: 'v20.19.4', npm: '10.8.2' }
npm warn EBADENGINE }
```

... as stated in the `package.json`:

```json
  "engines": {
    "node": ">=22",
    "npm": ">=10"
  },
```